### PR TITLE
added python path for utils

### DIFF
--- a/src/Gosai_2024_Evaluator/gosai_evaluator.def
+++ b/src/Gosai_2024_Evaluator/gosai_evaluator.def
@@ -4,13 +4,14 @@ Stage: build
 
 %files
     gosai_evaluator.py /Gosai_2024_Evaluator/gosai_evaluator.py
-    evaluator_utils.py /evaluator_script_and_utils/evaluator_utils.py
+    evaluator_utils.py /Gosai_2024_Evaluator/evaluator_utils.py
 
 %environment
     # Prevent automatic binding of host directories
     export APPTAINER_NO_MOUNT="home,tmp,proc,sys,dev"
     export LC_ALL=C
     export PATH="/usr/local/bin:$PATH"
+    export PYTHONPATH="/Gosai_2024_Evaluator:$PYTHONPATH"
 
 %post
     echo "Installing system dependencies..."
@@ -23,6 +24,7 @@ Stage: build
     pip3 install --no-cache-dir numpy pandas tqdm
 
     #echo "Setting permissions for directories and script..."
+    echo "Setting permissions for directories and script..."
     chmod -R 755 /Gosai_2024_Evaluator
 
 %runscript

--- a/src/agarwal_2025_evaluator/agarwal_evaluator.def
+++ b/src/agarwal_2025_evaluator/agarwal_evaluator.def
@@ -11,6 +11,7 @@ Stage: build
     export APPTAINER_NO_MOUNT="home,tmp,proc,sys,dev"
     export LC_ALL=C
     export PATH="/usr/local/bin:$PATH"
+    export PYTHONPATH="/evaluator_script_and_utils:$PYTHONPATH"
 
 %post
     # Install system packages and dependencies


### PR DESCRIPTION
When testing earlier version of the container, I got this error:

```
Traceback (most recent call last):
  File "/Gosai_2024_Evaluator/gosai_evaluator.py", line 11, in <module>
    from evaluator_utils import *
ModuleNotFoundError: No module named 'evaluator_utils'
```
The error indicates that Python cannot find the module evaluator_utils because it isn’t in the default module search path.