### PR TITLE
Changed permissions for directory inside the container using -R flag

### DIFF
--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_python_only.def
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_python_only.def
@@ -12,7 +12,7 @@ Stage: build
     export LD_LIBRARY_PATH="/opt/conda/lib:$LD_LIBRARY_PATH"
     
 %post
-    chmod 755 /evaluator_container_sample/evaluator_API_clean_apptainer.py
+    chmod -R 755 /evaluator_container_sample
 %runscript
     exec python3 /evaluator_container_sample/evaluator_API_clean_apptainer.py "$@"
 

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_python_only.def
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_python_only.def
@@ -17,7 +17,7 @@ Stage: build
 %post
     # Set permissions for copied files
     echo "Setting permissions..."
-    chmod 755 /predictor_container_sample
+    chmod -R 755 /predictor_container_sample
 
     echo "Installing Python dependencies..."
     python -m pip install --upgrade pip


### PR DESCRIPTION
Apptainer had issues accessing files inside the directory due to `chmod 755`. To fix this, `%post` section was updated to recursively set the permissions for all files in the directory, using `chmod -R 755`.