### PR TITLE
Fixed f-string syntax error by adjusting quote usage

### DIFF
--- a/src/Gosai_2024_Evaluator/gosai_evaluator.py
+++ b/src/Gosai_2024_Evaluator/gosai_evaluator.py
@@ -27,7 +27,7 @@ else:
 
 EVALUATOR_INPUT_PATH = os.path.join(EVALUATOR_DATA_DIR, input_file)
 
-output_json_filename = f"gosai_mpra_predictions_{input_file.replace(".txt", "")}.json"
+output_json_filename = f'gosai_mpra_predictions_{input_file.replace(".txt", "")}.json'
 
 # Set buffer size for TCP
 BUFFER_SIZE = 65536


### PR DESCRIPTION
- Resolved a `SyntaxError: f-string: unmatched '('` that occurred when constructing an output filename
- The original f-string used double quotes for its delimiters and also for string arguments within an internal `.replace()` method
- Changed the outer f-string delimiters to single quotes to ensure correct parsing and avoid conflicts