### PR TITLE
fix test pred/eval bugs

### DIFF
--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_API_clean_apptainer.py
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_API_clean_apptainer.py
@@ -15,7 +15,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # Define the input file name
 # This example Evaluator can only take .json/.msgpack inputs
 # ALERT: Variable names will change -- JSON-specific names will be changed
-input_file = "evaluator_message_gosai_1seq_test.json"
+input_file = "evaluator_message_more_complex.json"
 
 # Determine if running inside a container or not
 if os.path.exists("/.singularity.d"):

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_utils.py
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/evaluator_utils.py
@@ -79,70 +79,84 @@ def check_duplicates_from_string(json_string):
         # Handle invalid JSON format errors
         print(f"Invalid JSON: {e}")
         return None
+    
+# Function for check duplicates if input file is in JSON format
 
-# function to check for duplicate keys in the JSON file
 def check_duplicates_from_json(json_file_path):
     """
-    Parses a JSON file to detect and report any duplicate keys. If no duplicates
-    are found, the JSON data is read into a variable.
+    Parses a JSON file to detect and report any duplicate keys at the same level in the same object.
+    This function ensures that no keys are silently overwritten in dictionaries.
 
-    The aim of this function is to count each key's occurrences before
-    fully loading the JSON into a dictionary, allowing it to identify
-    duplicate keys in the JSON file.
+    The function uses a helper to track the number of times each key appears during parsing,
+    leveraging the `object_pairs_hook` parameter of `json.load()` to intercept key-value pairs 
+    before they are processed into a dictionary. If duplicates are detected at any level, they
+    are reported with their counts and paths. Keys reused in separate objects within arrays 
+    (e.g., lists) are not considered duplicates.
 
     Args:
         json_file_path (str): The path to the JSON file to parse and check for duplicates.
 
     Returns:
-        dict or None: Returns the parsed JSON data as a dictionary if no duplicates are found.
-                      Otherwise, prints the duplicate keys and returns None.
+        None:
+            - If no duplicates are found, returns None, prints "No duplicates found."
+            - If duplicates are found, prints the duplicate keys and their counts and returns None.
     """
 
-    # Initialize a Counter to track key occurrences
-    key_counts = Counter()
+    # Import necessary libraries
+    from collections import Counter
+    import json
 
-    # Use a helper function to track key occurrences while creating a dictionary
+    # Initialize a dictionary to track duplicate keys and their counts
+    duplicate_keys = {}
+
+    # Helper function to detect duplicates during JSON parsing
     def detect_duplicates(pairs):
         """
-        Detects duplicate keys by counting their occurrences.
+        Detects duplicate keys during JSON parsing and counts occurrences of each key.
 
-        This helper function intercepts key-value pairs as they are loaded
-        and increments the count for each key in key_counts. The function
-        also returns a dictionary of the pairs which is needed for json.load()
-        to continue creating the JSON object.
+        This function intercepts the key-value pairs provided by `json.load` and ensures that
+        duplicate keys are flagged. It constructs the dictionary normally but counts how often
+        each key appears, recording any keys that occur more than once.
 
         Args:
-            pairs (list of tuple): List of (key, value) pairs from JSON parsing.
+            pairs (list of tuple): A list of key-value pairs at the current level of the JSON.
 
         Returns:
-            dict: A dictionary created from key-value pairs.
+            dict: A dictionary created from the key-value pairs.
         """
-        # `pairs` is a list of key-value pairs in the order they appear in the JSON file
-        for keys, value in pairs:
-            # Increment the count for each key in `key_counts`
-            key_counts[keys] += 1
-        # Convert the pairs into a dictionary and feed into json.load
-        return dict(pairs)
+        # Use a local Counter to count occurrences of keys at this level
+        local_counts = Counter()
+        result_dict = {}
+        for key, value in pairs:
+            # Increment the count for each key
+            local_counts[key] += 1
+            # If the key is a duplicate, record it in the duplicate_keys dictionary
+            if local_counts[key] > 1:
+                duplicate_keys[key] = local_counts[key]
+            # Add the key-value pair to the resulting dictionary
+            result_dict[key] = value
+        return result_dict
 
     try:
-        # Load the JSON file with the custom function to detect duplicates
+        # Open and parse the JSON file, using the helper to track duplicates
         with open(json_file_path, 'r') as file:
             data = json.load(file, object_pairs_hook=detect_duplicates)
 
-        # Create a dictionary with only those keys that have a count greater than 1 (duplicates)
-        duplicates = {keys: count for keys, count in key_counts.items() if count > 1}
-
-        # Output the results
-        if duplicates:
-            print("Duplicate keys found:", duplicates)
-            return None
+        # Report duplicates if any were found
+        if duplicate_keys:
+            print("Duplicate keys found:")
+            for key, count in duplicate_keys.items():
+                print(f"Key: {key}, Count: {count}")
+            return None # Return None if duplicates are found
         else:
             print("No duplicates found.")
-            return data
+            return data # Return the parsed data if no duplicates.
 
     except FileNotFoundError:
+        # Handle the case where the file is not found
         print(f"File not found: {json_file_path}")
         return None
     except json.JSONDecodeError as e:
+        # Handle invalid JSON format errors
         print(f"Invalid JSON in file '{json_file_path}': {e}")
         return None

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/predictions/training_predictions_evaluator_message_more_complex.json
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/evaluator_container_sample/predictions/training_predictions_evaluator_message_more_complex.json
@@ -1,0 +1,62 @@
+{
+    "request": "predict",
+    "predictor_name": "deBoerTest_model",
+    "prediction_tasks": [
+        {
+            "name": "task1",
+            "type_requested": "expression",
+            "type_actual": "expression",
+            "cell_type_requested": "HEPG2",
+            "cell_type_actual": "K562",
+            "scale_prediction_requested": "log",
+            "scale_prediction_actual": "log",
+            "species_requested": "homo_sapiens",
+            "species_actual": "homo_sapiens",
+            "predictions": {
+                "seq1": [
+                    0
+                ],
+                "seq2": [
+                    0
+                ],
+                "random_seq": [
+                    1
+                ],
+                "enhancer": [
+                    0
+                ],
+                "control": [
+                    1
+                ]
+            }
+        },
+        {
+            "name": "ishika_trick",
+            "type_requested": "accessibility",
+            "type_actual": "expression",
+            "cell_type_requested": "K562",
+            "cell_type_actual": "K562",
+            "scale_prediction_requested": "log",
+            "scale_prediction_actual": "log",
+            "species_requested": "homo_sapiens",
+            "species_actual": "homo_sapiens",
+            "predictions": {
+                "seq1": [
+                    0
+                ],
+                "seq2": [
+                    0
+                ],
+                "random_seq": [
+                    0
+                ],
+                "enhancer": [
+                    1
+                ],
+                "control": [
+                    1
+                ]
+            }
+        }
+    ]
+}

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/deBoerTest_model.py
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/deBoerTest_model.py
@@ -6,7 +6,7 @@ import tqdm
 
 ## model specific checks that cause a "prediction_request_failed" error
 def check_seqs_specifications(sequences, json_return_error_model):
-    max_length = 400000
+    max_length = 600000
     for sequence in sequences:
         value = sequences[sequence]
         key = sequence
@@ -25,7 +25,7 @@ def fake_model_point(sequences, json_dict):
     predictions = {}
     # Use tqdm to show progress as we process each sequence.
     for sequence in tqdm.tqdm(sequences, desc="Processing sequences (point prediction)", unit="seq"):
-        predictions[sequence] = random.randint(0, 1)
+        predictions[sequence] = [random.randint(0, 1)]
     json_dict['predictions'] = predictions
     return json_dict
 

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_API_clean_apptainer.py
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_API_clean_apptainer.py
@@ -28,7 +28,7 @@ BUFFER_SIZE = 65536
 
 # ------ ADDITION: Configuration for Wire-Format ------
 SUPPORTED_REQUEST_FORMATS = [fmt.lower() for fmt in ["json"]] # Removed msgpack -- not supported
-SUPPORTED_RESPONSE_FORMATS = [fmt.lower() for fmt in ["json"]] # JSON is always supported even when not mentioned
+SUPPORTED_RESPONSE_FORMATS = [fmt.lower() for fmt in ["msgpack"]] # JSON is always supported even when not mentioned
 
 def send_payload(sock, payload_obj, wire_fmt):
     

--- a/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_API_clean_apptainer.py
+++ b/src/training_examples/Apptainer/Test_Evaluator_Predictor/predictor_container_sample/predictor_API_clean_apptainer.py
@@ -362,6 +362,7 @@ def recv_message_loop(client_socket):
 
         # Create JSON to return
         json_return = {'request': evaluator_json['request']}
+        json_return['predictor_name'] = "deBoerTest_model"
         # Prediction task is an array of objects for all requested tasks
         json_return['prediction_tasks'] = []
         # Loop through all the prediction tasks


### PR DESCRIPTION
- Fixed the check duplicates function, which was outdated, as it also flagged keys from different tasks.
- Changed the evaluator input file name.
- Updated `deBoerTest_model.py` to accept 600k seqs and produce list for point predictions.
- Predictor now returns `predictor_name` as per updated API JSON schema